### PR TITLE
KV v1: Create or update secrets

### DIFF
--- a/src/main/scala/com/drobisch/tresor/vault/KV.scala
+++ b/src/main/scala/com/drobisch/tresor/vault/KV.scala
@@ -1,12 +1,13 @@
 package com.drobisch.tresor.vault
 
 import sttp.client3._
+import io.circe.syntax._
 import cats.effect.{Clock, Sync}
 import com.drobisch.tresor.Secret
 
 final case class KeyValueContext(key: String)
 
-/** implementation of the vault KV engine API
+/** implementation of the vault KV v1 engine API
   *
   * https://www.vaultproject.io/api/secret/kv/kv-v1.html
   *
@@ -36,6 +37,30 @@ class KV[F[_]](val path: String)(implicit sync: Sync[F], clock: Clock[F])
     log.debug("response from vault: {}", response)
 
     parseLease(response)
+  }
+
+  /** creates or updates the secret in the path
+    *
+    * @param context
+    *   key value context with key and vault config
+    * @param data
+    *   the data to be stored
+    */
+  def createSecret(
+      context: (KeyValueContext, VaultConfig),
+      data: Map[String, Option[String]]
+  )(implicit secret: Secret[Lease]): F[Unit] = {
+    val (kv, vaultConfig) = context
+
+    val response = basicRequest
+      .post(uri"${vaultConfig.apiUrl}/$path/${kv.key}")
+      .body(data.asJson.noSpaces)
+      .header("X-Vault-Token", vaultConfig.token)
+      .send(backend)
+
+    log.debug("response from vault: {}", response)
+
+    parseEmptyResponse(response)
   }
 }
 

--- a/src/main/scala/com/drobisch/tresor/vault/SecretEngineProvider.scala
+++ b/src/main/scala/com/drobisch/tresor/vault/SecretEngineProvider.scala
@@ -187,6 +187,14 @@ abstract class SecretEngineProvider[Effect[_], ProviderContext, Config](implicit
     }
   }
 
+  protected def parseEmptyResponse(
+      response: Response[Either[String, String]]
+  ): Effect[Unit] = {
+    for {
+      _ <- sync.fromEither(response.body.left.map(new RuntimeException(_)))
+    } yield ()
+  }
+
   protected def fromDto(dto: LeaseDTO, now: Long): Lease = {
     Lease(
       leaseId = dto.lease_id,

--- a/src/test/scala/com/drobisch/tresor/vault/KVSpec.scala
+++ b/src/test/scala/com/drobisch/tresor/vault/KVSpec.scala
@@ -1,10 +1,14 @@
 package com.drobisch.tresor.vault
 
-import cats.effect.IO
+import cats.effect.{IO, Timer}
 import com.drobisch.tresor.{StepClock, WireMockSupport, vault}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.ExecutionContext
+import scala.util.Random
 
 class KVSpec extends AnyFlatSpec with Matchers with WireMockSupport {
   val log: Logger = LoggerFactory.getLogger(getClass)
@@ -44,6 +48,56 @@ class KVSpec extends AnyFlatSpec with Matchers with WireMockSupport {
         leaseDuration = Some(43200),
         1
       )
+    )
+  }
+
+  "KV provider" should "read an existing token from vault KV engine (uses Docker Vault with pre-stored secret)" ignore {
+    // Needs a v1 secret engine under "secret-v1" and a secret "foobar" with data: foo -> bar
+    implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
+    implicit val timer: Timer[IO] = cats.effect.IO.timer(executionContext)
+
+    val config = VaultConfig("http://0.0.0.0:8200/v1", "vault-plaintext-root-token")
+
+    val kvSecret: IO[Lease] =
+      KV[cats.effect.IO]("secret-v1").secret(KeyValueContext(key = "foobar"), config)
+
+    val result = kvSecret.unsafeRunSync()
+    result.data should be(
+      Map("foo" -> Some("bar"))
+    )
+  }
+
+  "KV provider" should "create, update and read a new token from vault KV engine (uses Docker Vault)" in {
+    // Needs a v1 secret engine under "secret-v1"
+    implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
+    implicit val timer: Timer[IO] = cats.effect.IO.timer(executionContext)
+
+    val config = VaultConfig("http://0.0.0.0:8200/v1", "vault-plaintext-root-token")
+
+    val secretName = Random.alphanumeric.take(10).mkString
+    def createKvSecret: IO[Unit] =
+      KV[cats.effect.IO]("secret-v1").createSecret(
+        (KeyValueContext(key = secretName), config),
+        Map("foo" -> Some("bar")))
+    def updateKvSecret: IO[Unit] =
+      KV[cats.effect.IO]("secret-v1").createSecret(
+        (KeyValueContext(key = secretName), config),
+        Map("foo" -> Some("baz")))
+    def kvSecret: IO[Lease] =
+      KV[cats.effect.IO]("secret-v1").secret(KeyValueContext(key = secretName), config)
+
+    val result = (for {
+      _ <- createKvSecret
+      secret1 <- kvSecret
+      _ <- updateKvSecret
+      secret2 <- kvSecret
+    } yield (secret1, secret2)).unsafeRunSync()
+
+    result._1.data should be(
+      Map("foo" -> Some("bar"))
+    )
+    result._2.data should be(
+      Map("foo" -> Some("baz"))
     )
   }
 }


### PR DESCRIPTION
Adds the ability to create or update secrets for the KV v1 engine.

Specs depend on the dockerized vault engine. Should they be converted to use a mock?